### PR TITLE
Use `map` instead of `andThen`

### DIFF
--- a/Decoders.elm
+++ b/Decoders.elm
@@ -51,17 +51,17 @@ dogDecoder =
 sexDecoder : Decoder Sex
 sexDecoder =
     string
-        |> Json.Decode.andThen
+        |> Json.Decode.map
             (\sexString ->
                 case sexString of
                     "male" ->
-                        Json.Decode.succeed Male
+                        Male
 
                     "female" ->
-                        Json.Decode.succeed Female
+                        Female
 
                     _ ->
-                        Json.Decode.succeed Unknown
+                        Unknown
             )
 
 


### PR DESCRIPTION
The `sexDecoder` is more complex than it needs to be. Because it's using
`andThen`, it needs to manually re-wrap the values using
`Json.Decode.succeed`.

At a conceptual level, the `sexDecoder` is transforming a string to
`Sex` via a mapping. This is a perfect use-case for the simpler
`Json.Decode.map` function.

Given that this is a reference repo, I assume you'd prefer the simpler implementation.