### PR TITLE
Use map with separate function instead of andThen

### DIFF
--- a/Decoders.elm
+++ b/Decoders.elm
@@ -51,18 +51,20 @@ dogDecoder =
 sexDecoder : Decoder Sex
 sexDecoder =
     string
-        |> Json.Decode.andThen
-            (\sexString ->
-                case sexString of
-                    "male" ->
-                        Json.Decode.succeed Male
+        |> Json.Decode.map sexFromString
 
-                    "female" ->
-                        Json.Decode.succeed Female
 
-                    _ ->
-                        Json.Decode.succeed Unknown
-            )
+sexFromString : String -> Sex
+sexFromString sexString =
+    case sexString of
+        "male" ->
+            Male
+
+        "female" ->
+            Female
+
+        _ ->
+            Unknown
 
 
 listDecoder : Decoder (List Dog)


### PR DESCRIPTION
The `sexDecoder` is more complex than it needs to be. Because it's using
`andThen`, it needs to manually re-wrap the values using
`Json.Decode.succeed`.

At a conceptual level, the `sexDecoder` is transforming a string to
`Sex` via a mapping. This is a perfect use-case for the simpler
`Json.Decode.map` function.

Given that this is a reference repo, I assume you'd prefer the simpler implementation.

In addition, this extracts the mapping function `String -> Sex` for easier readability/comprehension